### PR TITLE
74 mail reporte nodos

### DIFF
--- a/monitoreo/apps/dashboard/models.py
+++ b/monitoreo/apps/dashboard/models.py
@@ -11,8 +11,10 @@ from django_datajsonar.models import AbstractTask
 
 class IndicatorManager(models.Manager):
 
-    def sorted_indicators_on_date(self, date):
+    def sorted_indicators_on_date(self, date, node=None):
         indicators = self.filter(fecha=date)
+        if node:
+            indicators = indicators.filter(jurisdiccion_id=node.catalog_id)
 
         one_dimensional = {}
         multi_dimensional = {}

--- a/monitoreo/templates/reports/report.html
+++ b/monitoreo/templates/reports/report.html
@@ -4,14 +4,14 @@
     <p>Horario de finalización: {{ finish_time }}</p>
 
     <h4>Detalle</h4>
-    <p>Indicadores numéricos de Red:</p>
+    <p>Indicadores numéricos de {{ target }}:</p>
     <ul>
         {% for key, value in one_dimensional_indics.items %}
         <li>{{ key }}: {{ value }}</li>
         {% endfor %}
     </ul>
 
-    <p>Indicadores no numéricos de Red:</p>
+    <p>Indicadores no numéricos de {{ target }}:</p>
     <ul>
         {% for key, nested in multi_dimensional_indics.items %}
         <li>{{ key }}:

--- a/monitoreo/templates/reports/report.txt
+++ b/monitoreo/templates/reports/report.txt
@@ -1,11 +1,11 @@
 Horario de finalización: {{ finish_time }}
 
-Indicadores numéricos de Red:
+Indicadores numéricos de {{ target }}:
     {% for key, value in one_dimensional_indics.items %}
     {{ key }}: {{ value|default:"None" }}
     {% endfor %}
 
-Indicadores no numéricos de Red:
+Indicadores no numéricos de {{ target }}:
     {% for key, nested in multi_dimensional_indics.items %}
     {{ key }}:
         {% for key, value in nested.items %}


### PR DESCRIPTION
Closes #74 

- Agrega la funcionalidad para mandar mails a los administradores de los nodos. Para definir los recipientes del mail, usa la dirección de los usuarios marcados como admins de cada nodo.

- Agrega test del comportamiento