### PR TITLE
124 fixes series indicadores

### DIFF
--- a/monitoreo/apps/dashboard/admin.py
+++ b/monitoreo/apps/dashboard/admin.py
@@ -48,9 +48,8 @@ class IndicatorAdmin(ImportExportModelAdmin):
 
     def get_urls(self):
         urls = super(IndicatorAdmin, self).get_urls()
-        name = '%s_%s_indicadores.csv'
         extra_urls = [url(r'^(?P<node_id>.+)/series-indicadores/$',
-                          indicators_csv, name=name), ]
+                          indicators_csv, name='node_series'), ]
         return extra_urls + urls
 
 
@@ -70,7 +69,7 @@ class IndicatorRedAdmin(ImportExportModelAdmin):
     def get_urls(self):
         urls = super(IndicatorRedAdmin, self).get_urls()
         extra_urls = [url(r'^series-indicadores/$', indicators_csv,
-                          name='download_time_series'), ]
+                          name='network_series'), ]
         return extra_urls + urls
 
 
@@ -85,7 +84,8 @@ class IndicatorTypeAdmin(OrderedModelAdmin):
 
     def get_urls(self):
         urls = super(IndicatorTypeAdmin, self).get_urls()
-        extra_urls = [url(r'^(?P<model_id>.+)/(?P<direction>top|bottom)/$', self.order_move, name='order_move'), ]
+        extra_urls = [url(r'^(?P<model_id>.+)/(?P<direction>top|bottom)/$',
+                          self.order_move, name='order_move'), ]
         return extra_urls + urls
 
     def position_actions(self, obj):
@@ -139,7 +139,8 @@ class HarvestingNodeAdmin(admin.ModelAdmin):
 
     def federate(self, _, queryset):
         for harvesting_node in queryset:
-            task = models.FederationTask.objects.create(harvesting_node=harvesting_node)
+            task = models.FederationTask.objects.create(
+                harvesting_node=harvesting_node)
             federate_catalogs.delay(task)
     federate.short_description = 'Correr federacion'
 

--- a/monitoreo/apps/dashboard/helpers.py
+++ b/monitoreo/apps/dashboard/helpers.py
@@ -7,7 +7,6 @@ from six import text_type
 from pydatajson import DataJson
 
 from django.http import HttpResponse
-from django.utils import timezone
 
 from django_datajsonar.models import Dataset, Node
 
@@ -108,10 +107,13 @@ def download_time_series(indicators, node_id=None):
 
 def generate_time_series(indicators, output):
     dates = indicators.keys()
-    min_date = min(dates)
-    max_date = max(dates)
-    date_range = [min_date + datetime.timedelta(days=x) for x in
-                  range(0, (max_date - min_date).days + 1)]
+    if dates:
+        min_date = min(dates)
+        max_date = max(dates)
+        date_range = [min_date + datetime.timedelta(days=x) for x in
+                      range(0, (max_date - min_date).days + 1)]
+    else:
+        date_range = []
     fieldnames = ['indice_tiempo']
     fieldnames = fieldnames + list(IndicatorType.objects.filter(series=True)
                                    .values_list('nombre', flat=True))

--- a/monitoreo/apps/dashboard/helpers.py
+++ b/monitoreo/apps/dashboard/helpers.py
@@ -111,7 +111,7 @@ def generate_time_series(indicators, output):
     min_date = min(dates)
     max_date = max(dates)
     date_range = [min_date + datetime.timedelta(days=x) for x in
-                  range(0, (max_date-min_date).days + 1)]
+                  range(0, (max_date - min_date).days + 1)]
     fieldnames = ['indice_tiempo']
     fieldnames = fieldnames + list(IndicatorType.objects.filter(series=True)
                                    .values_list('nombre', flat=True))

--- a/monitoreo/apps/dashboard/helpers.py
+++ b/monitoreo/apps/dashboard/helpers.py
@@ -1,12 +1,13 @@
 #! coding: utf-8
 import json
 import csv
+import datetime
 
 from six import text_type
 from pydatajson import DataJson
 
 from django.http import HttpResponse
-from django.utils.timezone import localtime
+from django.utils import timezone
 
 from django_datajsonar.models import Dataset, Node
 
@@ -106,12 +107,18 @@ def download_time_series(indicators, node_id=None):
 
 
 def generate_time_series(indicators, output):
+    dates = indicators.keys()
+    min_date = min(dates)
+    max_date = max(dates)
+    date_range = [min_date + datetime.timedelta(days=x) for x in
+                  range(0, (max_date-min_date).days + 1)]
     fieldnames = ['indice_tiempo']
     fieldnames = fieldnames + list(IndicatorType.objects.filter(series=True)
                                    .values_list('nombre', flat=True))
     writer = csv.DictWriter(output, fieldnames, extrasaction='ignore')
     writer.writeheader()
-    for date in indicators:
+    for date in date_range:
+        indicators.setdefault(date, {})
         indicators[date].update({'indice_tiempo': date})
         writer.writerow(indicators[date])
     return output

--- a/monitoreo/apps/dashboard/models.py
+++ b/monitoreo/apps/dashboard/models.py
@@ -40,7 +40,7 @@ class IndicatorQuerySet(models.QuerySet):
         if node_id:
             indicators = indicators.filter(jurisdiccion_id=node_id)
 
-        numerical = {}
+        numerical = OrderedDict()
         for indicator in indicators:
             value = json.loads(indicator.indicador_valor)
             if isinstance(value, (float, int)):

--- a/monitoreo/apps/dashboard/tests/views_test.py
+++ b/monitoreo/apps/dashboard/tests/views_test.py
@@ -1,9 +1,159 @@
 #! coding: utf-8
+import csv
+import datetime
+
 from django.test import TestCase, Client
 from django.urls import reverse
+from django.utils.timezone import localdate
+
+from django_datajsonar.models import Node
+
+from monitoreo.apps.dashboard.models import Indicador, IndicadorRed, IndicatorType
 
 
 class ViewsTest(TestCase):
+    def setUp(self):
+        # set mock nodes
+        self.node1 = Node.objects.create(catalog_id='id1', catalog_url='url',
+                                         indexable=True)
+        self.node2 = Node.objects.create(catalog_id='id2', catalog_url='url',
+                                         indexable=True)
+
+        self.node1.admins.create(username='admin1', password='regular',
+                                 email='admin1@test.com', is_staff=False)
+        self.node2.admins.create(username='admin2', password='regular',
+                                 email='admin2@test.com', is_staff=False)
+
+        # set mock indicators
+        type_a = IndicatorType.objects.create(nombre='ind_a', tipo='RED')
+        type_b = IndicatorType.objects.create(nombre='ind_b', tipo='RED')
+        type_c = IndicatorType.objects.create(nombre='ind_c', tipo='RED',
+                                              resumen=True, series=False)
+        type_d = IndicatorType.objects.create(nombre='ind_d', tipo='RED',
+                                              resumen=True, mostrar=False,
+                                              series=False)
+        type_e = IndicatorType.objects.create(nombre='ind_e', tipo='RED',
+                                              mostrar=False)
+
+        types = [type_a, type_b, type_c, type_d, type_e]
+        values = ['42', '[["d1", "l1"], ["d2", "l2"]]', '{"k1": 1, "k2": 2}',
+                  '100', '1']
+        for t, v in zip(types, values):
+            IndicadorRed.objects.create(indicador_tipo=t, indicador_valor=v)
+
+        values = ['23', '[["d1", "l1"]]', '{"k2": 1}', '500', '2']
+        for t, v in zip(types, values):
+            Indicador.objects.create(indicador_tipo=t, indicador_valor=v,
+                                     jurisdiccion_id='id1',
+                                     jurisdiccion_nombre='nodo1')
+
+        values = ['19', '[["d2", "l2"]]', '{"k1": 1, "k2": 1}', '50', '2']
+        for t, v in zip(types, values):
+            Indicador.objects.create(indicador_tipo=t, indicador_valor=v,
+                                     jurisdiccion_id='id2',
+                                     jurisdiccion_nombre='nodo2')
+
+        # Necesario para agregar los indicadores con fecha distinta a la de hoy
+        values = ['23', '[["d1", "l1"]]', '{"k1":1, "k2": 2, "k3": 10}',
+                  '50', '0']
+        old_ids = []
+        for ind_type, value in zip(types, values):
+            old = IndicadorRed.objects.create(indicador_tipo=ind_type,
+                                              indicador_valor=value)
+            old_ids.append(old.id)
+
+        self.past_date = localdate() - datetime.timedelta(days=2)
+        IndicadorRed.objects.filter(id__in=old_ids).update(
+            fecha=self.past_date)
+
+        # Indicadores
+        values = ['22', '["d1", "l1"]', '{"k3":2, "k1": 2}']
+        for ind_type, value in zip(types, values):
+            Indicador.objects.create(indicador_tipo=ind_type,
+                                     indicador_valor=value,
+                                     jurisdiccion_nombre='catalogo_de_test_1',
+                                     jurisdiccion_id='test_1')
+
+        values = ['20', '["d2", "l2"]', '{"k3":1, "k2": 1}']
+        for ind_type, value in zip(types, values):
+            Indicador.objects.create(indicador_tipo=ind_type,
+                                     indicador_valor=value,
+                                     jurisdiccion_nombre='catalogo_de_test_2',
+                                     jurisdiccion_id='test_2')
+
+        Indicador.objects.create(indicador_tipo=type_a,
+                                 indicador_valor='00',
+                                 jurisdiccion_nombre='catalogo_de_test_2',
+                                 jurisdiccion_id=None)
+
+    def format_previous_dates(self, delta):
+        return (localdate() - datetime.timedelta(days=delta))\
+            .strftime('%Y-%m-%d')
+
     def test_landing_with_no_indicators_loaded_returns_500(self):
+        IndicadorRed.objects.all().delete()
         response = Client().get(reverse('dashboard:landing'))
         self.assertEqual(response.status_code, 500)
+
+    def test_series_headers(self):
+        network_response = Client().get(reverse('admin:network_series'))
+        expected_disposition =\
+            'attachment; filename="series-indicadores-red.csv"'
+        self.assertEqual(expected_disposition,
+                         network_response['Content-Disposition'])
+
+        node_response = Client().get(reverse('admin:node_series',
+                                             kwargs={'node_id': 'id1'}))
+        expected_disposition = \
+            'attachment; filename="series-indicadores-id1.csv"'
+        self.assertEqual(expected_disposition,
+                         node_response['Content-Disposition'])
+
+    def test_series_header(self):
+        network_response = Client().get(reverse('admin:network_series'))
+        series = csv.reader(network_response.content.splitlines())
+        expected_headers = {'indice_tiempo', 'ind_a', 'ind_b', 'ind_e'}
+        headers = next(series, None)
+        self.assertSetEqual(expected_headers, set(headers))
+
+    def test_series_rows(self):
+        network_response = Client().get(reverse('admin:network_series'))
+        series = network_response.content.splitlines()
+        self.assertEqual(4, len(series))
+        series_csv = csv.DictReader(series)
+        two_days_ago = self.format_previous_dates(2)
+        expected_row = {'indice_tiempo': two_days_ago,
+                        'ind_a': '23',
+                        'ind_b': '',
+                        'ind_e': '0'}
+        row = next(series_csv, None)
+        self.assertDictEqual(expected_row, row)
+        yesterday = self.format_previous_dates(1)
+        expected_row = {'indice_tiempo': yesterday,
+                        'ind_a': '',
+                        'ind_b': '',
+                        'ind_e': ''}
+        row = next(series_csv, None)
+        self.assertDictEqual(expected_row, row)
+        today = self.format_previous_dates(0)
+        expected_row = {'indice_tiempo': today,
+                        'ind_a': '42',
+                        'ind_b': '',
+                        'ind_e': '1'}
+        row = next(series_csv, None)
+        self.assertDictEqual(expected_row, row)
+
+    def test_node_series(self):
+        node_response = Client().get(reverse('admin:node_series',
+                                             kwargs={'node_id': 'id1'}))
+        series = node_response.content.splitlines()
+        self.assertEqual(2, len(series))
+        series_csv = csv.DictReader(series)
+        today = self.format_previous_dates(0)
+        expected_row = {'indice_tiempo': today,
+                        'ind_a': '23',
+                        'ind_b': '',
+                        'ind_e': '2'}
+        row = next(series_csv, None)
+        self.assertDictEqual(expected_row, row)
+

--- a/monitoreo/apps/dashboard/tests/views_test.py
+++ b/monitoreo/apps/dashboard/tests/views_test.py
@@ -156,4 +156,3 @@ class ViewsTest(TestCase):
                         'ind_e': '2'}
         row = next(series_csv, None)
         self.assertDictEqual(expected_row, row)
-

--- a/monitoreo/apps/dashboard/tests/views_test.py
+++ b/monitoreo/apps/dashboard/tests/views_test.py
@@ -19,11 +19,6 @@ class ViewsTest(TestCase):
         self.node2 = Node.objects.create(catalog_id='id2', catalog_url='url',
                                          indexable=True)
 
-        self.node1.admins.create(username='admin1', password='regular',
-                                 email='admin1@test.com', is_staff=False)
-        self.node2.admins.create(username='admin2', password='regular',
-                                 email='admin2@test.com', is_staff=False)
-
         # set mock indicators
         type_a = IndicatorType.objects.create(nombre='ind_a', tipo='RED')
         type_b = IndicatorType.objects.create(nombre='ind_b', tipo='RED')
@@ -66,25 +61,6 @@ class ViewsTest(TestCase):
         IndicadorRed.objects.filter(id__in=old_ids).update(
             fecha=self.past_date)
 
-        # Indicadores
-        values = ['22', '["d1", "l1"]', '{"k3":2, "k1": 2}']
-        for ind_type, value in zip(types, values):
-            Indicador.objects.create(indicador_tipo=ind_type,
-                                     indicador_valor=value,
-                                     jurisdiccion_nombre='catalogo_de_test_1',
-                                     jurisdiccion_id='test_1')
-
-        values = ['20', '["d2", "l2"]', '{"k3":1, "k2": 1}']
-        for ind_type, value in zip(types, values):
-            Indicador.objects.create(indicador_tipo=ind_type,
-                                     indicador_valor=value,
-                                     jurisdiccion_nombre='catalogo_de_test_2',
-                                     jurisdiccion_id='test_2')
-
-        Indicador.objects.create(indicador_tipo=type_a,
-                                 indicador_valor='00',
-                                 jurisdiccion_nombre='catalogo_de_test_2',
-                                 jurisdiccion_id=None)
 
     def format_previous_dates(self, delta):
         return (localdate() - datetime.timedelta(days=delta))\


### PR DESCRIPTION
Closes #124 

- Corrige las series de timpo de indicadores. Ordena los días y pone filas en blanco para las fechas faltantes.
- Agrega tests sobre las series descargadas.