### PR TITLE
Fix recoleccion indicadores federadores

### DIFF
--- a/monitoreo/apps/dashboard/helpers.py
+++ b/monitoreo/apps/dashboard/helpers.py
@@ -100,14 +100,15 @@ def list_errors(msg, errors):
     return msg
 
 
-def download_time_series(indicators, node_id=None):
+def download_time_series(queryset, node_id=None):
     response = HttpResponse(content_type='text/csv')
     filename = 'series-indicadores-{}.csv'.format(node_id or 'red')
     response['Content-Disposition'] = 'attachment; filename="%s"' % filename
-    return generate_time_series(indicators, response, node_id is None)
+    return generate_time_series(queryset, response)
 
 
-def generate_time_series(indicators, output, aggregated=False):
+def generate_time_series(queryset, output):
+    indicators = queryset.numerical_indicators_by_date()
     dates = indicators.keys()
     if dates:
         min_date = min(dates)
@@ -117,12 +118,8 @@ def generate_time_series(indicators, output, aggregated=False):
     else:
         date_range = []
 
-    if aggregated:
-        ind_types = IndicatorType.objects.filter(series_red=True)
-    else:
-        ind_types = IndicatorType.objects.filter(series_nodos=True)
-
-    columns = list(ind_types.values_list('nombre', flat=True))
+    columns = list(set(queryset.values_list(
+        'indicador_tipo__nombre', flat=True)))
     fieldnames = ['indice_tiempo']
     fieldnames = fieldnames + columns
 

--- a/monitoreo/apps/dashboard/helpers.py
+++ b/monitoreo/apps/dashboard/helpers.py
@@ -100,16 +100,16 @@ def list_errors(msg, errors):
     return msg
 
 
-def download_time_series(queryset, node_id=None):
+def download_time_series(indicators_queryset, node_id=None):
     response = HttpResponse(content_type='text/csv')
     filename = 'series-indicadores-{}.csv'.format(node_id or 'red')
     response['Content-Disposition'] = 'attachment; filename="%s"' % filename
-    return generate_time_series(queryset, response)
+    return generate_time_series(indicators_queryset, response)
 
 
-def generate_time_series(queryset, output):
-    indicators = queryset.numerical_indicators_by_date()
-    dates = indicators.keys()
+def generate_time_series(indicators_queryset, output):
+    indicators_table = indicators_queryset.numerical_indicators_by_date()
+    dates = indicators_table.keys()
     if dates:
         min_date = min(dates)
         max_date = max(dates)
@@ -118,7 +118,7 @@ def generate_time_series(queryset, output):
     else:
         date_range = []
 
-    columns = list(set(queryset.values_list(
+    columns = list(set(indicators_queryset.values_list(
         'indicador_tipo__nombre', flat=True)))
     fieldnames = ['indice_tiempo']
     fieldnames = fieldnames + columns
@@ -126,7 +126,7 @@ def generate_time_series(queryset, output):
     writer = csv.DictWriter(output, fieldnames, extrasaction='ignore')
     writer.writeheader()
     for date in date_range:
-        indicators.setdefault(date, {})
-        indicators[date].update({'indice_tiempo': date})
-        writer.writerow(indicators[date])
+        indicators_table.setdefault(date, {})
+        indicators_table[date].update({'indice_tiempo': date})
+        writer.writerow(indicators_table[date])
     return output

--- a/monitoreo/apps/dashboard/tests/views_test.py
+++ b/monitoreo/apps/dashboard/tests/views_test.py
@@ -26,10 +26,12 @@ class ViewsTest(TestCase):
                                               series_nodos=False)
         type_c = IndicatorType.objects.create(nombre='ind_c', tipo='RED',
                                               resumen=True, series_red=False,
-                                              series_nodos=False)
+                                              series_nodos=False,
+                                              series_indexadores=False)
         type_d = IndicatorType.objects.create(nombre='ind_d', tipo='RED',
                                               resumen=True, mostrar=False,
-                                              series_red=False)
+                                              series_red=False,
+                                              series_indexadores=False)
         type_e = IndicatorType.objects.create(nombre='ind_e', tipo='RED',
                                               mostrar=False)
 
@@ -157,7 +159,7 @@ class ViewsTest(TestCase):
         today = self._format_previous_dates(0)
         expected_row = {'indice_tiempo': today,
                         'ind_a': '21',
-                        'ind_d': '200',
+                        'ind_b': '',
                         'ind_e': '4'}
         row = next(series_csv, None)
         self.assertDictEqual(expected_row, row)

--- a/monitoreo/apps/dashboard/views.py
+++ b/monitoreo/apps/dashboard/views.py
@@ -98,10 +98,11 @@ def indicators_csv(request, node_id=None, indexing=False):
             filter(indicador_tipo__series_red=True)
     elif indexing:
         queryset = IndicadorFederador.objects.\
-            filter(indicador_tipo__series_indexadores=True)
+            filter(indicador_tipo__series_indexadores=True,
+                   jurisdiccion_id=node_id)
     else:
         queryset = Indicador.objects.\
-            filter(indicador_tipo__series_nodos=True)
+            filter(indicador_tipo__series_nodos=True,
+                   jurisdiccion_id=node_id)
 
-    indicators = queryset.numerical_indicators_by_date(node_id=node_id)
-    return download_time_series(indicators, node_id=node_id)
+    return download_time_series(queryset, node_id=node_id)


### PR DESCRIPTION
Closes datosgobar/django-datajsonar#82

- Refactor de cómo saca los tipos de indicadores para el csv
- Actualiza el test para diferenciarlo de los indicadores de nodos