### PR TITLE
reorden de apps del admin

### DIFF
--- a/conf/settings/base.py
+++ b/conf/settings/base.py
@@ -93,6 +93,7 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'admin_reorder.middleware.ModelAdminReorder',
 )
 
 ANONYMOUS_USER_ID = -1
@@ -158,13 +159,14 @@ VENDOR_APPS = (
     'import_export',
     'django_rq',
     'scheduler',
+    'des',
     'solo',
+    'admin_reorder',
 )
 
 APPS = (
     'monitoreo.apps.dashboard',
     'django_datajsonar',
-    'monitoreo.apps.dashboard.apps.CustomDesConfig',
 )
 
 INSTALLED_APPS = DJANGO_BASE_APPS + VENDOR_APPS + APPS
@@ -391,3 +393,12 @@ DATAJSONAR_STAGES = {
         'task': 'monitoreo.apps.dashboard.models.ValidationReportTask'
     }
 }
+
+ADMIN_REORDER = (
+    str('auth'),
+    str('django_datajsonar'),
+    str('dashboard'),
+    {'app': 'des', 'label': 'Configuración correo'},
+    str('scheduler'),
+    str('sites'),
+)

--- a/monitoreo/apps/dashboard/apps.py
+++ b/monitoreo/apps/dashboard/apps.py
@@ -2,13 +2,7 @@
 from __future__ import unicode_literals
 
 from django.apps import AppConfig
-from des.apps import DjangoDesConfig
 
 
 class DashboardConfig(AppConfig):
     name = 'dashboard'
-
-
-class CustomDesConfig(DjangoDesConfig):
-    verbose_name = 'Configuración correo'
-    verbose_name_plural = verbose_name

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,3 +8,4 @@ google-api-python-client
 django-import-export==0.5.1
 django-solo==1.1.3
 -e git+git://github.com/datosgobar/django-datajsonar@0.1.20#egg=django_datajsonar
+django-modeladmin-reorder==0.3.1


### PR DESCRIPTION
Closes #147 

- Agrega `django-modeladmin-reorder` y ordena las apps según el issue (django-rq no se puede ordenar porque no es una aplicación. Es una vista que agrega `django-rq-scheduler`)