### PR TITLE
116 indicator csv column order

### DIFF
--- a/monitoreo/apps/dashboard/helpers.py
+++ b/monitoreo/apps/dashboard/helpers.py
@@ -11,7 +11,7 @@ from django.http import HttpResponse
 
 from django_datajsonar.models import Dataset
 
-from .models import IndicatorsGenerationTask
+from .models import IndicatorsGenerationTask, IndicatorType
 from .strings import OVERALL_ASSESSMENT, VALIDATION_ERRORS, MISSING, HARVESTING_ERRORS, ERRORS_DIVIDER
 
 
@@ -118,9 +118,12 @@ def generate_time_series(indicators_queryset, output):
     else:
         date_range = []
 
-    columns = list(set(indicators_queryset.values_list(
-        'indicador_tipo__nombre', flat=True)))
+    ind_types = set(indicators_queryset.values_list('indicador_tipo__id',
+                                                    flat=True))
     fieldnames = ['indice_tiempo']
+    columns = IndicatorType.objects.filter(id__in=ind_types).order_by('order')\
+        .values_list('nombre', flat=True)
+    columns = list(columns)
     fieldnames = fieldnames + columns
 
     writer = csv.DictWriter(output, fieldnames, extrasaction='ignore')

--- a/monitoreo/apps/dashboard/helpers.py
+++ b/monitoreo/apps/dashboard/helpers.py
@@ -118,8 +118,8 @@ def generate_time_series(indicators_queryset, output):
     else:
         date_range = []
 
-    ind_types = set(indicators_queryset.values_list('indicador_tipo__id',
-                                                    flat=True))
+    ind_types = indicators_queryset\
+        .values_list('indicador_tipo__id', flat=True).distinct()
     fieldnames = ['indice_tiempo']
     columns = IndicatorType.objects.filter(id__in=ind_types).order_by('order')\
         .values_list('nombre', flat=True)

--- a/monitoreo/apps/dashboard/tests/views_test.py
+++ b/monitoreo/apps/dashboard/tests/views_test.py
@@ -109,6 +109,23 @@ class ViewsTest(TestCase):
         headers = next(series, None)
         self.assertSetEqual(expected_headers, set(headers))
 
+    def test_header_respects_indicator_type_order(self):
+        network_response = Client().get(reverse('admin:network_series'))
+        series = csv.reader(network_response.content.splitlines())
+        expected_headers = {'indice_tiempo', 'ind_a', 'ind_b', 'ind_e'}
+        headers = next(series, None)
+        self.assertSetEqual(expected_headers, set(headers))
+
+        type_a = IndicatorType.objects.get(nombre='ind_a')
+        type_e = IndicatorType.objects.filter(nombre='ind_e')
+        type_a.swap(type_e)
+
+        network_response = Client().get(reverse('admin:network_series'))
+        series = csv.reader(network_response.content.splitlines())
+        expected_headers = {'indice_tiempo', 'ind_e', 'ind_b', 'ind_a'}
+        headers = next(series, None)
+        self.assertSetEqual(expected_headers, set(headers))
+
     def test_series_rows(self):
         network_response = Client().get(reverse('admin:network_series'))
         series = network_response.content.splitlines()

--- a/monitoreo/apps/dashboard/tests/views_test.py
+++ b/monitoreo/apps/dashboard/tests/views_test.py
@@ -110,12 +110,6 @@ class ViewsTest(TestCase):
         self.assertSetEqual(expected_headers, set(headers))
 
     def test_header_respects_indicator_type_order(self):
-        network_response = Client().get(reverse('admin:network_series'))
-        series = csv.reader(network_response.content.splitlines())
-        expected_headers = {'indice_tiempo', 'ind_a', 'ind_b', 'ind_e'}
-        headers = next(series, None)
-        self.assertSetEqual(expected_headers, set(headers))
-
         type_a = IndicatorType.objects.get(nombre='ind_a')
         type_e = IndicatorType.objects.filter(nombre='ind_e')
         type_a.swap(type_e)


### PR DESCRIPTION
Closes datosgobar/django-datajsonar#116

- Define el orden de las columnas por el orden de los indicadores de tipos
- Agrega test para el orden