### PR TITLE
Renombro las urls de csv de indicadores

### DIFF
--- a/monitoreo/apps/dashboard/urls.py
+++ b/monitoreo/apps/dashboard/urls.py
@@ -1,16 +1,16 @@
 #! coding: utf-8
 from django.conf.urls import url
 
-from monitoreo.apps.dashboard.views import red_nodos, indicadores_red_csv, \
-    nodos_indicadores_csv, nodos_indicadores_federadores_csv, \
+from monitoreo.apps.dashboard.views import red_nodos, indicadores_red_nodos_csv, \
+    indicadores_nodos_csv, indicadores_nodos_federadores_csv, \
     indicadores_red_series, indicadores_nodos_series, \
     indicadores_federadores_series
 
 urlpatterns = [
     url(r'^nodos$', red_nodos, name='nodos'),
-    url(r'^indicadores-red.csv$', indicadores_red_csv, name="indicadores-red-csv"),
-    url(r'^indicadores-nodo.csv$', nodos_indicadores_csv, name="indicadores-nodo-csv"),
-    url(r'^indicadores-federadores.csv$', nodos_indicadores_federadores_csv, name="indicadores-federadores-csv"),
+    url(r'^indicadores/indicadores-red-nodos.csv$', indicadores_red_nodos_csv, name="indicadores-red-csv"),
+    url(r'^indicadores/indicadores-nodos.csv$', indicadores_nodos_csv, name="indicadores-nodo-csv"),
+    url(r'^indicadores/indicadores-nodos-federadores.csv$', indicadores_nodos_federadores_csv, name="indicadores-federadores-csv"),
     url(r'^indicadores/indicadores-red-nodos-series.csv$',
         indicadores_red_series, name="indicadores-red-series"),
     url(r'^indicadores/nodos/(?P<filename>[\w|-]+.csv)$',

--- a/monitoreo/apps/dashboard/views.py
+++ b/monitoreo/apps/dashboard/views.py
@@ -98,17 +98,17 @@ def create_response_from_indicator_model(model, fieldnames, filename):
     return response
 
 
-def indicadores_red_csv(_request):
+def indicadores_red_nodos_csv(_request):
     fieldnames = ['fecha', 'indicador_tipo__nombre', 'indicador_valor']
     return create_response_from_indicator_model(IndicadorRed, fieldnames, 'indicadores-red')
 
 
-def nodos_indicadores_csv(_request):
+def indicadores_nodos_csv(_request):
     fieldnames = ['fecha', 'indicador_tipo__nombre', 'indicador_valor', 'jurisdiccion_nombre', 'jurisdiccion_id']
     return create_response_from_indicator_model(Indicador, fieldnames, 'indicadores-nodo')
 
 
-def nodos_indicadores_federadores_csv(_request):
+def indicadores_nodos_federadores_csv(_request):
     fieldnames = ['fecha', 'indicador_tipo__nombre', 'indicador_valor', 'jurisdiccion_nombre', 'jurisdiccion_id']
     return create_response_from_indicator_model(IndicadorFederador, fieldnames, 'indicadores-federadores')
 

--- a/monitoreo/templates/header.html
+++ b/monitoreo/templates/header.html
@@ -1,9 +1,6 @@
 {% load static %}
 <div id="header">
     <div id="header-content" class="container no-padding">
-        <a href="{% url 'dashboard:landing' %}">
-            <img src="{% static 'img/logo_ministerio.svg' %}" class="header-logo">
-        </a>
 
         <a href="https://medium.com/datos-argentina" target="_blank" class="pull-right">
             <i class="fa fa-medium fa-2x" aria-hidden="true"></i>


### PR DESCRIPTION
- Renombro urls que sirven los csv de indicadores de nodos:
{url_base}/indicadores-red.csv ---> {url_base}/indicadores/indicadores-red-nodos.csv
{url_base}/indicadores-nodo.csv ---> {url_base}/indicadores/indicadores-nodos.csv
{url_base}/indicadores-federadores.csv ---> {url_base}/indicadores/indicadores-nodos-federadores.csv

- Renombro funciones en views para mantener coherencia con las nuevas urls
