### PR TITLE
Cambiar nombres de endpoints y archivos

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -230,10 +230,15 @@ acepta es csv.
 
 Además, accediendo a las siguientes rutas, se pueden descargar los siguientes dumps:
 
-- `/indicadores-red.csv`: descarga un dump de la base de indicadores de red
+- `/indicadores/indicadores-red-nodos.gz`: descarga un dump comprimido de la base de indicadores de red
 en formato.csv
-- `/indicadores-nodo.csv`: descarga un dump de los indicadores de nodos
-- `/indicadores-federadores.csv`: descarga un dump de los indicadores federadores
+- `/indicadores/indicadores-nodos.gz`: descarga un dump de los indicadores de nodos
+- `/indicadores/indicadores-federadores.csv`: descarga un dump de los indicadores federadores
+- `/indicadores/indicadores-red-nodos-series.csv`: descarga un dump de los indicadores de nodos de series
+- `/indicadores/nodos/$nombre_archivo$.csv`: remplazando `$nombre_archivo$` con el nombre de archivo deseado, 
+descarga un dump de los nodos guardados con el nombre de archivo especificado.
+- `/indicadores/nodos-federadores/$nombre_archivo$.csv`: remplazando `$nombre_archivo$` con el nombre de archivo deseado, 
+descarga un dump de los nodos federadores guardados con el nombre de archivo especificado.
 - `/nodos.json`: devuelve (no descarga) la información de todos los nodos (id y nombre de los nodos,
 nombre de jurisdicción, urls de descarga de datos, etc). Se puede descargar esta información en
 formato **csv** o **xlsx** accediendo a `/nodos.csv` o `/nodos.xlsx` respectivamente

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -230,15 +230,23 @@ acepta es csv.
 
 Además, accediendo a las siguientes rutas, se pueden descargar los siguientes dumps:
 
-- `/indicadores/indicadores-red-nodos.gz`: descarga un dump comprimido de la base de indicadores de red
-en formato.csv
-- `/indicadores/indicadores-nodos.gz`: descarga un dump de los indicadores de nodos
-- `/indicadores/indicadores-federadores.csv`: descarga un dump de los indicadores federadores
-- `/indicadores/indicadores-red-nodos-series.csv`: descarga un dump de los indicadores de nodos de series
-- `/indicadores/nodos/$nombre_archivo$.csv`: remplazando `$nombre_archivo$` con el nombre de archivo deseado, 
-descarga un dump de los nodos guardados con el nombre de archivo especificado.
-- `/indicadores/nodos-federadores/$nombre_archivo$.csv`: remplazando `$nombre_archivo$` con el nombre de archivo deseado, 
-descarga un dump de los nodos federadores guardados con el nombre de archivo especificado.
+- `/indicadores/indicadores-red-nodos.gz`: descarga un dump **comprimido** de la base de indicadores de red
+en formato `.csv`
+- `/indicadores/indicadores-nodos.gz`: descarga un dump **comprimido** de los indicadores de nodos 
+en formato `.csv`
+- `/indicadores/indicadores-nodos-federadores.gz`: descarga un dump **comprimido** de los indicadores federadores 
+en formato `.csv`.
+- `/indicadores/panel-red.csv`: estando logueado en el sistema, descarga un dump de la base de indicadores de red
+en formato `.csv`
+- `/indicadores/panel-nodos.csv`: estando logueado en el sistema, descarga un dump de los indicadores de nodos 
+en formato `.csv`
+- `/indicadores/panel-nodos-federadores.csv`: estando logueado en el sistema, descarga un dump de los indicadores federadores 
+en formato `.csv`.
+- `/indicadores/indicadores-red-nodos-series.csv`: descarga un archivo `.csv` de las series de tiempo de indicadores de red.
+- `/indicadores/nodos/indicadores-$id$-series.csv`: remplazando `$id$` con el numero identificador del nodo deseado, 
+descarga un archivo `.csv` comprimido de su serie de tiempo de indicadores.
+- `/indicadores/nodos-federadores/indicadores-$id$-series.csv`: remplazando `$id$` con el numero identificador 
+del nodo federador deseado, descarga un archivo `.csv` comprimido de su serie de tiempo de indicadores.
 - `/nodos.json`: devuelve (no descarga) la información de todos los nodos (id y nombre de los nodos,
 nombre de jurisdicción, urls de descarga de datos, etc). Se puede descargar esta información en
 formato **csv** o **xlsx** accediendo a `/nodos.csv` o `/nodos.xlsx` respectivamente

--- a/monitoreo/apps/dashboard/urls.py
+++ b/monitoreo/apps/dashboard/urls.py
@@ -6,9 +6,9 @@ from monitoreo.apps.dashboard.views import indicadores_red_nodos_csv, indicadore
     indicadores_federadores_series, panel_federadores_zip, panel_nodos_zip, panel_red_zip
 
 urlpatterns = [
-    url(r'^indicadores/indicadores-red-nodos.csv$', panel_red_zip, name="indicadores-red-zip"),
-    url(r'^indicadores/indicadores-nodos.csv$', panel_nodos_zip, name="indicadores-nodo-zip"),
-    url(r'^indicadores/indicadores-nodos-federadores.csv$', panel_federadores_zip, name="indicadores-federadores-zip"),
+    url(r'^indicadores/indicadores-red-nodos.gz$', panel_red_zip, name="indicadores-red-zip"),
+    url(r'^indicadores/indicadores-nodos.gz$', panel_nodos_zip, name="indicadores-nodo-zip"),
+    url(r'^indicadores/indicadores-nodos-federadores.gz$', panel_federadores_zip, name="indicadores-federadores-zip"),
 
     url(r'^indicadores/panel-red.csv$', indicadores_red_nodos_csv, name="indicadores-red-csv"),
     url(r'^indicadores/panel-nodos.csv$', indicadores_nodos_csv, name="indicadores-nodo-csv"),

--- a/monitoreo/apps/dashboard/views.py
+++ b/monitoreo/apps/dashboard/views.py
@@ -49,19 +49,19 @@ def indicadores_nodos_federadores_csv(_request):
 def panel_red_zip(_request):
     filename = 'indicadores-red.csv.gz'
     path = os.path.join(settings.MEDIA_ROOT, 'indicator_files', filename)
-    return csv_zip_response('indicadores-red-nodos.csv.gz', path)
+    return csv_zip_response('indicadores-red-nodos.gz', path)
 
 
 def panel_nodos_zip(_request):
     filename = 'indicadores-nodos.csv.gz'
     path = os.path.join(settings.MEDIA_ROOT, 'indicator_files', 'nodes', filename)
-    return csv_zip_response('indicadores-nodos.csv.gz', path)
+    return csv_zip_response('indicadores-nodos.gz', path)
 
 
 def panel_federadores_zip(_request):
     filename = 'indicadores-nodos-federadores.csv.gz'
     path = os.path.join(settings.MEDIA_ROOT, 'indicator_files', 'federator-nodes', filename)
-    return csv_zip_response(filename, path)
+    return csv_zip_response('indicadores-nodos-federadores.gz', path)
 
 
 def indicadores_red_series(_request):


### PR DESCRIPTION
Se corrigieron los nombres de los enpoints para descargar dumps como tambien los nombres de los archivos que se descargan. Se le hace un update de la documentación agregando los nuevos enpoints

closes #236 