### PR TITLE
258- Log de federación más explícito

### DIFF
--- a/monitoreo/apps/dashboard/helpers.py
+++ b/monitoreo/apps/dashboard/helpers.py
@@ -25,7 +25,7 @@ def load_catalogs(task, nodes, harvesting=False):
                 catalog = DataJson(node.catalog_url,
                                    catalog_format=node.catalog_format)
         except Exception as e:
-            msg = 'Error accediendo al catálogo {}: {}'.format(node.catalog_id, str(e))
+            msg = f'Error accediendo al catálogo {node.catalog_id}: {str(e)}'
             IndicatorsGenerationTask.info(task, msg)
             continue
 
@@ -60,7 +60,7 @@ def generate_task_log(catalog, catalog_id, invalid, missing, harvested_ids, fede
 def append_federation_errors(log, errors):
     log += ERRORS_DIVIDER.format('FEDERACIÓN')
     for dataset in errors:
-        log += dataset + ": " + errors[dataset] + "\n"
+        log += f"{dataset}: {errors[dataset]}\n"
     return log
 
 
@@ -71,21 +71,21 @@ def append_validation_errors(log, validation):
         log = list_errors(log, validation['error']['catalog']['errors'])
 
     for dataset in validation['error']['dataset']:
-        log += "Errores en el dataset: {} \n".format(dataset['identifier'])
+        log += f"Errores en el dataset: {dataset['identifier']} \n"
         log = list_errors(log, dataset['errors'])
     return log
 
 
 def list_errors(msg, errors):
     for error in errors:
-        msg += '\t {}: {} \n'.format(text_type(error['path']), error['message'])
+        msg += f"\t {text_type(error['path'])}: {error['message']} \n"
     return msg
 
 
 def download_time_series(indicators_queryset, node_id=None):
     response = HttpResponse(content_type='text/csv')
-    filename = 'series-indicadores-{}.csv'.format(node_id or 'red')
-    response['Content-Disposition'] = 'attachment; filename="%s"' % filename
+    filename = f"series-indicadores-{node_id or 'red'}.csv"
+    response['Content-Disposition'] = f'attachment; filename="{filename}"'
     return generate_time_series(indicators_queryset, response)
 
 

--- a/monitoreo/apps/dashboard/helpers.py
+++ b/monitoreo/apps/dashboard/helpers.py
@@ -25,7 +25,7 @@ def load_catalogs(task, nodes, harvesting=False):
                 catalog = DataJson(node.catalog_url,
                                    catalog_format=node.catalog_format)
         except Exception as e:
-            msg = u'Error accediendo al catálogo {}: {}'.format(node.catalog_id, str(e))
+            msg = 'Error accediendo al catálogo {}: {}'.format(node.catalog_id, str(e))
             IndicatorsGenerationTask.info(task, msg)
             continue
 
@@ -36,8 +36,10 @@ def load_catalogs(task, nodes, harvesting=False):
 
 def generate_task_log(catalog, catalog_id, invalid, missing, harvested_ids, federation_errors):
     validation = catalog.validate_catalog(only_errors=True)
-    total = Dataset.objects.filter(indexable=True, catalog__identifier=catalog_id).count()
-    log = OVERALL_ASSESSMENT.format(len(harvested_ids), total)
+    indexable_datasets = Dataset.objects.filter(indexable=True, catalog__identifier=catalog_id)
+    total = indexable_datasets.count()
+    present = indexable_datasets.filter(present=True).count()
+    log = OVERALL_ASSESSMENT.format(len(harvested_ids), present, total)
     if invalid:
         log += VALIDATION_ERRORS.format(len(invalid), list(invalid))
 
@@ -56,27 +58,27 @@ def generate_task_log(catalog, catalog_id, invalid, missing, harvested_ids, fede
 
 
 def append_federation_errors(log, errors):
-    log += ERRORS_DIVIDER.format(u'FEDERACIÓN')
+    log += ERRORS_DIVIDER.format('FEDERACIÓN')
     for dataset in errors:
-        log += dataset + u": " + errors[dataset] + u"\n"
+        log += dataset + ": " + errors[dataset] + "\n"
     return log
 
 
 def append_validation_errors(log, validation):
-    log += ERRORS_DIVIDER.format(u'VALIDACIÓN')
+    log += ERRORS_DIVIDER.format('VALIDACIÓN')
     if validation['error']['catalog']['status'] == 'ERROR':
-        log += u"Errores de catalogo: \n"
+        log += "Errores de catalogo: \n"
         log = list_errors(log, validation['error']['catalog']['errors'])
 
     for dataset in validation['error']['dataset']:
-        log += u"Errores en el dataset: {} \n".format(dataset['identifier'])
+        log += "Errores en el dataset: {} \n".format(dataset['identifier'])
         log = list_errors(log, dataset['errors'])
     return log
 
 
 def list_errors(msg, errors):
     for error in errors:
-        msg += u'\t {}: {} \n'.format(text_type(error['path']), error['message'])
+        msg += '\t {}: {} \n'.format(text_type(error['path']), error['message'])
     return msg
 
 

--- a/monitoreo/apps/dashboard/indicators_tasks.py
+++ b/monitoreo/apps/dashboard/indicators_tasks.py
@@ -78,7 +78,7 @@ def save_network_indics(network_indics, indic_class, task):
                                               indicador_tipo=indic_type,
                                               defaults={'indicador_valor': json.dumps(value)})
 
-    IndicatorsGenerationTask.info(task, u'Calculados {} indicadores de red'.format(len(network_indics)))
+    IndicatorsGenerationTask.info(task, 'Calculados {} indicadores de red'.format(len(network_indics)))
 
 
 def save_indicators(indics_list, task, harvesting_nodes=False):
@@ -113,10 +113,10 @@ def save_indicators(indics_list, task, harvesting_nodes=False):
                 indic_models += 1
             except DataError:
                 IndicatorsGenerationTask.info(
-                    task, u"Error guardando indicador: {0} - {1}: {2}"
+                    task, "Error guardando indicador: {0} - {1}: {2}"
                     .format(catalog_name, indic_type, json.dumps(value)))
 
-    msg = u'Calculados {0} indicadores en {1} catálogos'\
+    msg = 'Calculados {0} indicadores en {1} catálogos'\
         .format(indic_models, len(indics_list))
     if harvesting_nodes:
         msg += ' federadores'

--- a/monitoreo/apps/dashboard/models/nodes.py
+++ b/monitoreo/apps/dashboard/models/nodes.py
@@ -10,7 +10,7 @@ class HarvestingNode(models.Model):
         verbose_name_plural = "Nodos federadores"
 
     def __unicode__(self):
-        return u'%s' % self.name
+        return '%s' % self.name
 
     def __str__(self):
         return self.__unicode__()

--- a/monitoreo/apps/dashboard/report_generators.py
+++ b/monitoreo/apps/dashboard/report_generators.py
@@ -56,7 +56,7 @@ class IndicatorReportGenerator(AbstractReportGenerator):
         """
 
         start_time = self._format_date(self.indicators_task.created)
-        subject = u'[{}] Indicadores Monitoreo Apertura ({}): {}'\
+        subject = '[{}] Indicadores Monitoreo Apertura ({}): {}'\
             .format(settings.ENV_TYPE, context['target'], start_time)
         mail = self.render_templates(context)
         mail.subject = subject
@@ -154,7 +154,7 @@ class ValidationReportGenerator(AbstractReportGenerator):
         }
 
         mail = self.render_templates(context)
-        subject = u'[{}] Validacion de catálogo {}: {}'.format(
+        subject = '[{}] Validacion de catálogo {}: {}'.format(
             settings.ENV_TYPE, node.catalog_id, validation_time)
         mail.subject = subject
 
@@ -169,7 +169,7 @@ class ValidationReportGenerator(AbstractReportGenerator):
         context = {'error': error}
         validation_time = self._format_date(timezone.now())
         mail = self.render_error_templates(context)
-        subject = u'[{}] Error validando catálogo {}: {}'.format(
+        subject = '[{}] Error validando catálogo {}: {}'.format(
             settings.ENV_TYPE, node.catalog_id, validation_time)
         mail.subject = subject
         return mail

--- a/monitoreo/apps/dashboard/strings.py
+++ b/monitoreo/apps/dashboard/strings.py
@@ -1,15 +1,15 @@
 #! coding: utf-8
 
-UNREACHABLE_CATALOG = u"No se puede acceder al catálogo {}\n"
+UNREACHABLE_CATALOG = "No se puede acceder al catálogo {}\n"
 
-OVERALL_ASSESSMENT = u"Se federaron {} de {} datasets.\n"
+OVERALL_ASSESSMENT = "Se federaron {} de {} datasets presentes (habiendo {} datasets totales).\n"
 
-VALIDATION_ERRORS = u"{} tuvieron errores de validacion:\n {} \n"
+VALIDATION_ERRORS = "{} tuvieron errores de validacion:\n {} \n"
 
-MISSING = u"{} ausentes:\n {} \n"
+MISSING = "{} ausentes:\n {} \n"
 
-HARVESTING_ERRORS = u"{} tuvieron errores de federación:\n {} \n"
+HARVESTING_ERRORS = "{} tuvieron errores de federación:\n {} \n"
 
-TASK_ERROR = u"Error federando catalog: {} datasets: {} - Error: {}\n"
+TASK_ERROR = "Error federando catalog: {} datasets: {} - Error: {}\n"
 
-ERRORS_DIVIDER = u"####### ERRORES DE {} ####### \n"
+ERRORS_DIVIDER = "####### ERRORES DE {} ####### \n"

--- a/monitoreo/apps/dashboard/tasks.py
+++ b/monitoreo/apps/dashboard/tasks.py
@@ -39,7 +39,7 @@ def federate_catalog(node, portal_url, apikey, task_id):
     task = FederationTask.objects.get(pk=task_id)
     catalog = get_catalog_from_node(node)
     catalog_id = node.catalog_id
-    msg = "Catálogo: %s\n" % node.catalog_id
+    msg = f"Catálogo: {node.catalog_id}\n"
     if not catalog:
         msg += UNREACHABLE_CATALOG.format(node.catalog_id)
         FederationTask.info(task, msg)

--- a/monitoreo/apps/dashboard/tasks.py
+++ b/monitoreo/apps/dashboard/tasks.py
@@ -39,7 +39,7 @@ def federate_catalog(node, portal_url, apikey, task_id):
     task = FederationTask.objects.get(pk=task_id)
     catalog = get_catalog_from_node(node)
     catalog_id = node.catalog_id
-    msg = u"Catálogo: %s\n" % node.catalog_id
+    msg = "Catálogo: %s\n" % node.catalog_id
     if not catalog:
         msg += UNREACHABLE_CATALOG.format(node.catalog_id)
         FederationTask.info(task, msg)

--- a/monitoreo/apps/dashboard/tests/indicators_report_tests.py
+++ b/monitoreo/apps/dashboard/tests/indicators_report_tests.py
@@ -113,7 +113,7 @@ class IndicatorReportGenerationTest(TestCase):
 
     def test_subject(self):
         start_time = timezone.localtime(self.indicators_task.created).strftime('%Y-%m-%d %H:%M:%S')
-        subject = u'[tst] Indicadores Monitoreo Apertura (Red): {}'.format(start_time)
+        subject = '[tst] Indicadores Monitoreo Apertura (Red): {}'.format(start_time)
         self.assertEqual(subject, self.mail.subject)
 
     def test_mail_header(self):

--- a/monitoreo/apps/dashboard/tests/validation_report_tests.py
+++ b/monitoreo/apps/dashboard/tests/validation_report_tests.py
@@ -71,7 +71,7 @@ class ValidationReportGenerationTest(TestCase):
         self.assertEqual(['admin1@test.com'], self.mail.to)
 
     def test_subject(self):
-        subject = u'[tst] Validacion de catálogo id1: 2010-10-10 07:00:00'
+        subject = '[tst] Validacion de catálogo id1: 2010-10-10 07:00:00'
         self.assertEqual(subject, self.mail.subject)
 
     def test_mail_uses_des_from(self):


### PR DESCRIPTION
#### Contexto
- Hago que los logs de las corridas de federación sean más explícito, detallando cuántos de los datasets tenidos en cuenta eran presentes (y no sólo los totales).
- Elimino todos los `u` antes de las strings, que eran necesarios cuando se utilizaba Python 2.

#### Cómo probarlo
En un entorno local, agregar (o elegir, si ya existiese) un nodo federable con datasets presentes y no presentes. Realizar una corrida de federación y observar las cantidades detalladas en los logs de la corrida (la cantidad total siempre debería ser mayor al a de datasets presentes, y esta debería también ser mayor o igual a la de datasets federados).

Closes #258 