### PR TITLE
Corrección error al intentar importar task

### DIFF
--- a/monitoreo/apps/dashboard/models/__init__.py
+++ b/monitoreo/apps/dashboard/models/__init__.py
@@ -3,4 +3,5 @@ from .indicator_types import IndicatorType, TableColumn
 from .indicators import Indicador, IndicadorRed, IndicadorFederador
 from .nodes import HarvestingNode, CentralNode
 from .tasks import ReportGenerationTask, ValidationReportTask,\
-    IndicatorsGenerationTask, FederationTask, NewlyReportGenerationTask
+    IndicatorsGenerationTask, FederationTask, NewlyReportGenerationTask, \
+    NotPresentReportGenerationTask

--- a/monitoreo/apps/dashboard/tests/tasks_importable_test.py
+++ b/monitoreo/apps/dashboard/tests/tasks_importable_test.py
@@ -1,0 +1,24 @@
+from unittest import TestCase
+
+from django_datajsonar.utils.utils import import_string
+
+
+class TasksAreImportableTest(TestCase):
+
+    def test_report_generation_task_is_importable(self):
+        self.assertIsNotNone(import_string('monitoreo.apps.dashboard.models.ReportGenerationTask'))
+
+    def test_validation_report_task_is_importable(self):
+        self.assertIsNotNone(import_string('monitoreo.apps.dashboard.models.ValidationReportTask'))
+
+    def test_indicators_generation_task_is_importable(self):
+        self.assertIsNotNone(import_string('monitoreo.apps.dashboard.models.IndicatorsGenerationTask'))
+
+    def test_federation_task_is_importable(self):
+        self.assertIsNotNone(import_string('monitoreo.apps.dashboard.models.FederationTask'))
+
+    def test_newly_report_generation_task_is_importable(self):
+        self.assertIsNotNone(import_string('monitoreo.apps.dashboard.models.NewlyReportGenerationTask'))
+
+    def test_not_present_report_generation_task_is_importable(self):
+        self.assertIsNotNone(import_string('monitoreo.apps.dashboard.models.NotPresentReportGenerationTask'))


### PR DESCRIPTION
Faltaba la importación en el init de dashboard models, por eso no lo encontraba como modelo "importable".
Se agrego este import al init.py y tambien se agregaron tests para verificar que sigan estando.

closes #277