### PR TITLE
migracion que corrije los callable str de django_datajsonar

### DIFF
--- a/monitoreo/apps/dashboard/migrations/0059_federation_task_callable_str_django_datajsonar_correction_migration.py
+++ b/monitoreo/apps/dashboard/migrations/0059_federation_task_callable_str_django_datajsonar_correction_migration.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def convert_callable_str(apps, _schema_editor):
+    stage_model = apps.get_model('django_datajsonar', 'Stage')
+    stages = stage_model.objects\
+        .filter(callable_str__contains="django_datajsonar.federation_tasks.")
+    for stage in stages:
+        stage.callable_str =\
+            stage.callable_str\
+            .replace("django_datajsonar.federation_tasks.", "django_datajsonar.tasks.")
+        stage.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dashboard', '0058_federation_task_callable_str_migration_correction'),
+    ]
+
+    operations = [
+        migrations.RunPython(convert_callable_str, migrations.RunPython.noop)
+    ]


### PR DESCRIPTION
Con la última migración  de monitoreo (0058) algunos stages de datajsonar que tenian un callable_str de la forma "django_datajsonar.tasks...." se cambiaron incorrectamente a "django_datajsonar.federation_tasks...", el cual no existe, esta migracion corrije esos casos.