### PR TITLE
Correccion de logs y mejora de performance

### DIFF
--- a/monitoreo/apps/dashboard/federation_tasks.py
+++ b/monitoreo/apps/dashboard/federation_tasks.py
@@ -48,8 +48,8 @@ def federate_catalog(node, portal_url, apikey, task_id):
         LOGGER.warning(msg)
         return msg
     catalog.generate_distribution_ids()
-    url_validation = TasksConfig.get_solo().federation_url_check
-    catalog_report = catalog.validate_catalog(broken_links=url_validation)
+    catalog_report = catalog.validate_catalog(
+        broken_links=TasksConfig.get_solo().federation_url_check)
     valid, invalid, missing = sort_datasets_by_condition(node, catalog_report)
 
     try:

--- a/monitoreo/apps/dashboard/federation_tasks.py
+++ b/monitoreo/apps/dashboard/federation_tasks.py
@@ -2,11 +2,11 @@
 
 import json
 import logging
-from django_rq import job
 
+from django_datajsonar.models import Node, Dataset
+from django_rq import job
 from pydatajson.core import DataJson
 from pydatajson.federation import harvest_catalog_to_ckan
-from django_datajsonar.models import Node, Dataset
 
 from monitoreo.apps.dashboard.models.tasks import TasksConfig
 from .helpers import generate_task_log
@@ -48,13 +48,15 @@ def federate_catalog(node, portal_url, apikey, task_id):
         LOGGER.warning(msg)
         return msg
     catalog.generate_distribution_ids()
-    valid, invalid, missing = sort_datasets_by_condition(node, catalog)
+    url_validation = TasksConfig.get_solo().federation_url_check
+    catalog_report = catalog.validate_catalog(broken_links=url_validation)
+    valid, invalid, missing = sort_datasets_by_condition(node, catalog_report)
 
     try:
         harvested_ids, federation_errors = harvest_catalog_to_ckan(catalog, portal_url, apikey, catalog_id, list(valid),
                                                                    origin_tz=node.timezone,
                                                                    dst_tz=task.harvesting_node.timezone)
-        msg += generate_task_log(catalog, catalog_id, invalid, missing, harvested_ids, federation_errors)
+        msg += generate_task_log(catalog_report, catalog_id, invalid, missing, harvested_ids, federation_errors)
         FederationTask.info(task, msg)
         LOGGER.warning(msg)
         return msg
@@ -66,9 +68,7 @@ def federate_catalog(node, portal_url, apikey, task_id):
         return msg
 
 
-def sort_datasets_by_condition(node, catalog):
-    url_validation = TasksConfig.get_solo().federation_url_check
-    catalog_report = catalog.validate_catalog(broken_links=url_validation)
+def sort_datasets_by_condition(node, catalog_report):
     valid_set = {ds['identifier'] for ds in catalog_report['error']['dataset'] if ds['status'] == 'OK'}
     invalid_set = {ds['identifier'] for ds in catalog_report['error']['dataset'] if ds['status'] == 'ERROR'}
     dataset_models = set(Dataset.objects.filter(catalog__identifier=node.catalog_id, indexable=True, present=True,)

--- a/monitoreo/apps/dashboard/helpers.py
+++ b/monitoreo/apps/dashboard/helpers.py
@@ -1,14 +1,13 @@
 #! coding: utf-8
 import csv
 import datetime
-
 from urllib.parse import urljoin
-from six import text_type
-from pydatajson import DataJson
 
 from django.http import HttpResponse
-
 from django_datajsonar.models import Dataset, Catalog, Node
+from pydatajson import DataJson
+from six import text_type
+
 from .models import IndicatorsGenerationTask, IndicatorType
 from .strings import OVERALL_ASSESSMENT, VALIDATION_ERRORS, MISSING, HARVESTING_ERRORS, ERRORS_DIVIDER
 
@@ -35,7 +34,7 @@ def load_catalogs(task, nodes, harvesting=False):
 
 
 def generate_task_log(catalog, catalog_id, invalid, missing, harvested_ids, federation_errors):
-    validation = catalog.validate_catalog(only_errors=True)
+    validation = catalog.validate_catalog(only_errors=True, broken_links=True)
     indexable_datasets = Dataset.objects.filter(indexable=True, catalog__identifier=catalog_id)
     total = indexable_datasets.count()
     present = indexable_datasets.filter(present=True).count()

--- a/monitoreo/apps/dashboard/helpers.py
+++ b/monitoreo/apps/dashboard/helpers.py
@@ -33,8 +33,11 @@ def load_catalogs(task, nodes, harvesting=False):
     return catalogs
 
 
-def generate_task_log(catalog, catalog_id, invalid, missing, harvested_ids, federation_errors):
-    validation = catalog.validate_catalog(only_errors=True, broken_links=True)
+def generate_task_log(catalog_report, catalog_id, invalid, missing, harvested_ids, federation_errors):
+    validation = catalog_report
+    # filtra los resultados que dieron error
+    validation["error"]["dataset"] = \
+        list(filter(lambda d: d["status"] == "ERROR", validation["error"]["dataset"]))
     indexable_datasets = Dataset.objects.filter(indexable=True, catalog__identifier=catalog_id)
     total = indexable_datasets.count()
     present = indexable_datasets.filter(present=True).count()


### PR DESCRIPTION
Se extrae la validacion del catalogo mas afuera para evitar que se haga 2 veces, de esta forma tambien se resuelve el problema de logs faltantes ya que en generate_logs faltaba poner que se use la validacion de broken links si eso decia la configuración.

closes #296 