### PR TITLE
Correcciones al validador de catálogos

### DIFF
--- a/monitoreo/apps/validator/static/js/main.js
+++ b/monitoreo/apps/validator/static/js/main.js
@@ -1,0 +1,5 @@
+function loadingButton(button) {
+    button.form.submit();
+    button.disabled = true;
+    button.classList.add('state-loading');
+}

--- a/monitoreo/apps/validator/templates/validator.html
+++ b/monitoreo/apps/validator/templates/validator.html
@@ -60,7 +60,8 @@
 
             <div class="row">
                 <div class="col-md-8 col-md-offset-2">
-                    <input value="Validar" type="submit" class="btn btn-primary">
+                    <button onclick="this.form.submit(); this.disabled=true; this.classList.add('state-loading');"
+                            type="submit" class="btn btn-primary">Validar</button>
                 </div>
             </div>
 

--- a/monitoreo/apps/validator/templates/validator.html
+++ b/monitoreo/apps/validator/templates/validator.html
@@ -60,7 +60,7 @@
 
             <div class="row">
                 <div class="col-md-8 col-md-offset-2">
-                    <button onclick="this.form.submit(); this.disabled=true; this.classList.add('state-loading');"
+                    <button onclick="loadingButton(this);"
                             type="submit" class="btn btn-primary">Validar</button>
                 </div>
             </div>
@@ -69,5 +69,6 @@
 
     </div>
 
+<script src="{% static 'js/main.js' %}"></script>
 </body>
 </html>

--- a/monitoreo/apps/validator/validator.py
+++ b/monitoreo/apps/validator/validator.py
@@ -19,7 +19,7 @@ class Validator:
     def validate_fields(self):
         base_request_error_message = "Error descargando el catálogo: "
         try:
-            response = requests.head(self.catalog_url)
+            response = requests.head(self.catalog_url, verify=False)
             response.raise_for_status()
         except MissingSchema:
             raise ValidationError(base_request_error_message + "el url ingresado "

--- a/monitoreo/apps/validator/validator.py
+++ b/monitoreo/apps/validator/validator.py
@@ -40,11 +40,9 @@ class Validator:
             raise ValidationError(parse_error_message)
 
     def get_catalog_errors(self):
-        validate_broken_urls = TasksConfig().get_solo().validation_url_check
-
         catalog = DataJson(catalog=self.catalog_url, catalog_format=self.catalog_format)
 
-        all_errors = catalog.validate_catalog(only_errors=True, broken_links=validate_broken_urls)
+        all_errors = catalog.validate_catalog(only_errors=True)
         error_messages = []
 
         catalog_validation = all_errors['error']['catalog']

--- a/monitoreo/apps/validator/validator.py
+++ b/monitoreo/apps/validator/validator.py
@@ -2,7 +2,7 @@ import logging
 
 import requests
 # pylint: disable=W0622
-from requests.exceptions import ConnectionError, MissingSchema, RequestException
+from requests.exceptions import ConnectionError, MissingSchema, RequestException, InvalidSchema
 from django.core.exceptions import ValidationError
 from pydatajson import DataJson
 from pydatajson.custom_exceptions import NonParseableCatalog
@@ -21,7 +21,7 @@ class Validator:
         try:
             response = requests.head(self.catalog_url, verify=False)
             response.raise_for_status()
-        except MissingSchema:
+        except (MissingSchema, InvalidSchema):
             raise ValidationError(base_request_error_message + "el url ingresado "
                                                                "no es un url válido")
         except ConnectionError:


### PR DESCRIPTION
- El setting de validar broken urls ya no se toma de lo configurado en TaskConfig. Ahora nunca se hace ese chequeo
- Al validar los campos del form, desactivo la verificación SSL al hacer un head al url ingresado.
- Contemplo excepción InvalidSchema en validacion de campos del form, que salta si se ingresa un file path local.
- Agrego feedback al boton validar: se hace unclickable y parece que carga al submitear un form.

Pair programing con @AWolfsdorf 

Closes #311 